### PR TITLE
Remove extra data in ChannelOpen

### DIFF
--- a/Surfus.Shell/Messages/Channel/ChannelOpen.cs
+++ b/Surfus.Shell/Messages/Channel/ChannelOpen.cs
@@ -53,7 +53,7 @@ namespace Surfus.Shell.Messages.Channel
 
         protected ByteWriter GetByteWriter(int additionalSize)
         {
-            var writer = new ByteWriter(Type, 16 + ChannelType.GetAsciiStringSize() + additionalSize);
+            var writer = new ByteWriter(Type, 12 + ChannelType.GetAsciiStringSize() + additionalSize);
             writer.WriteAsciiString(ChannelType);
             writer.WriteUint(SenderChannel);
             writer.WriteUint(InitialWindowSize);


### PR DESCRIPTION
Opening a channel may fail when connecting to OpenSSH, at there's extra/unused data in the packet.